### PR TITLE
Give access to /proc/sys/vm/overcommit_memory to all domains

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -99,6 +99,10 @@ allow domain self:process { fork sigchld };
 # glibc get_nprocs requires read access to /sys/devices/system/cpu/online
 dev_read_cpu_online(domain)
 
+# glibc malloc requires access to /proc/sys/vm/overcommit_memory
+# see https://sourceware.org/git/?p=glibc.git;a=commit;h=9fab36eb
+kernel_read_vm_overcommit_sysctls(domain)
+
 # Use trusted objects in /dev
 dev_rw_null(domain)
 dev_rw_zero(domain)

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -3222,10 +3222,10 @@ interface(`kernel_unconfined',`
 #
 interface(`kernel_search_vm_overcommit_sysctl',`
 	gen_require(`
-		type proc_t, sysctl_t, sysctl_vm_overcommit_t;
+		type proc_t, sysctl_t, sysctl_vm_t, sysctl_vm_overcommit_t;
 	')
 
-	search_dirs_pattern($1, { proc_t sysctl_t }, sysctl_vm_overcommit_t)
+	search_dirs_pattern($1, { proc_t sysctl_t sysctl_vm_t }, sysctl_vm_overcommit_t)
 ')
 
 ########################################
@@ -3241,10 +3241,10 @@ interface(`kernel_search_vm_overcommit_sysctl',`
 #
 interface(`kernel_read_vm_overcommit_sysctls',`
 	gen_require(`
-		type proc_t, sysctl_t, sysctl_vm_overcommit_t;
+		type proc_t, sysctl_t, sysctl_vm_t, sysctl_vm_overcommit_t;
 	')
 
-	read_files_pattern($1, { proc_t sysctl_t sysctl_vm_overcommit_t }, sysctl_vm_overcommit_t)
+	read_files_pattern($1, { proc_t sysctl_t sysctl_vm_t sysctl_vm_overcommit_t }, sysctl_vm_overcommit_t)
 ')
 
 ########################################
@@ -3260,9 +3260,9 @@ interface(`kernel_read_vm_overcommit_sysctls',`
 #
 interface(`kernel_rw_vm_overcommit_sysctls',`
 	gen_require(`
-		type proc_t, sysctl_t, sysctl_vm_overcommit_t;
+		type proc_t, sysctl_t, sysctl_vm_t, sysctl_vm_overcommit_t;
 	')
 
-	rw_files_pattern($1 ,{ proc_t sysctl_t sysctl_vm_overcommit_t }, sysctl_vm_overcommit_t)
-	list_dirs_pattern($1, { proc_t sysctl_t }, sysctl_vm_overcommit_t)
+	rw_files_pattern($1 ,{ proc_t sysctl_t sysctl_vm_t sysctl_vm_overcommit_t }, sysctl_vm_overcommit_t)
+	list_dirs_pattern($1, { proc_t sysctl_t sysctl_vm_t }, sysctl_vm_overcommit_t)
 ')

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -3209,3 +3209,60 @@ interface(`kernel_unconfined',`
 	typeattribute $1 kern_unconfined;
 	kernel_load_module($1)
 ')
+
+########################################
+## <summary>
+## 	Allow caller to search virtual memory overcommit sysctls.
+## </summary>
+## <param name="domain">
+## 	<summary>
+## 	Domain allowed access.
+## 	</summary>
+## </param>
+#
+interface(`kernel_search_vm_overcommit_sysctl',`
+	gen_require(`
+		type proc_t, sysctl_t, sysctl_vm_overcommit_t;
+	')
+
+	search_dirs_pattern($1, { proc_t sysctl_t }, sysctl_vm_overcommit_t)
+')
+
+########################################
+## <summary>
+## 	Allow caller to read virtual memory overcommit sysctls.
+## </summary>
+## <param name="domain">
+## 	<summary>
+## 	Domain allowed access.
+## 	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kernel_read_vm_overcommit_sysctls',`
+	gen_require(`
+		type proc_t, sysctl_t, sysctl_vm_overcommit_t;
+	')
+
+	read_files_pattern($1, { proc_t sysctl_t sysctl_vm_overcommit_t }, sysctl_vm_overcommit_t)
+')
+
+########################################
+## <summary>
+## 	Read and write virtual memory overcommit sysctls.
+## </summary>
+## <param name="domain">
+## 	<summary>
+## 	Domain allowed access.
+## 	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kernel_rw_vm_overcommit_sysctls',`
+	gen_require(`
+		type proc_t, sysctl_t, sysctl_vm_overcommit_t;
+	')
+
+	rw_files_pattern($1 ,{ proc_t sysctl_t sysctl_vm_overcommit_t }, sysctl_vm_overcommit_t)
+	list_dirs_pattern($1, { proc_t sysctl_t }, sysctl_vm_overcommit_t)
+')

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -153,6 +153,10 @@ genfscon proc /sys/net/unix gen_context(system_u:object_r:sysctl_net_unix_t,s0)
 type sysctl_vm_t, sysctl_type;
 genfscon proc /sys/vm gen_context(system_u:object_r:sysctl_vm_t,s0)
 
+# /proc/sys/vm/overcommit_memory
+type sysctl_vm_overcommit_t, sysctl_type;
+genfscon proc /sys/vm/overcommit_memory gen_context(system_u:object_r:sysctl_vm_overcommit_t,s0)
+
 # /proc/sys/dev directory and files
 type sysctl_dev_t, sysctl_type;
 genfscon proc /sys/dev gen_context(system_u:object_r:sysctl_dev_t,s0)


### PR DESCRIPTION
A lot of domain seems to be asking for the following rights:
allow \* sysctl_vm_t:dir search;
allow \* sysctl_vm_t:file { read open };

Digging a little, I found https://bugzilla.redhat.com/show_bug.cgi?id=872729 which lead me to:
- Fedora fix: https://git.fedorahosted.org/cgit/selinux-policy.git/commit/?id=343c0887514718387f36ee8ead2b941ba9bfb894
- Glibc change: https://sourceware.org/git/?p=glibc.git;a=commit;h=9fab36eb583c0e585e83a01253299afed9ea9a11

The access seems to be useless unless /proc/sys/vm/overcommit_memory contains '2', but I see no reasons not to allow it.

Compiling the policy works, but I can't use it right now as the genfscon proc does not seem to apply...
